### PR TITLE
use swarm-manifest content type, instead of dag-pb by default for Swarm

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ module.exports = {
 	fromSwarm: function (swarmHash) {
 		swarmHash = hexString(swarmHash)
 		let multihash = multiH.encode(swarmHash, 'keccak-256')	// get Multihash buffer
-		let res = new CID(1, 'dag-pb', multihash)				// create a CIDv1 with the multihash
+		let res = new CID(1, 'swarm-manifest', multihash)				// create a CIDv1 with the multihash
 		res = multiC.addPrefix('swarm-ns', res.buffer)			// add swarm codec prefix
 		return res.toString('hex')
 	},

--- a/test/test.js
+++ b/test/test.js
@@ -5,8 +5,8 @@ const contentHash = require('../index.js')
 
 const ipfs = 'QmRAQB6YaCyidP37UdDnjFY5vQuiBrcqdyoW1CuDgwxkD4'
 const ipfs_contentHash = 'e3010170122029f2d17be6139079dc48696d1f582a8530eb9805b561eda517e22a892c7e3f1f'
-const swarm = 'd1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162'
-const swarm_contentHash = 'e40101701b20d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162'
+const swarm = '74f5b67c088a34a7b51612671300c9f040f4b8b322fa234d26069c17eb00428a'
+const swarm_contentHash = 'e40101701b2074f5b67c088a34a7b51612671300c9f040f4b8b322fa234d26069c17eb00428a'
 
 describe('content-hash', () => 
 	{


### PR DESCRIPTION
Swarm Multicodes were added at https://github.com/multiformats/multicodec/pull/120 therefore I think we should amend this library as well.

Currently there are two types within Swarm - manifests and feeds. I didn't want to change the API from `fromSwarm`, to `fromSwarmManifest`, so as a start I suggest just updating the default content type from `dag-pb` to `swarm-manifest`.

cc @justelad