### PR TITLE
Add ZeroNet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here you can find a [live demo](https://content-hash.surge.sh/) of this package.
 - `ipns-ns`
 - `onion`
 - `onion3`
+- `zeronet`
 
 ## 📥 Install
 * via **npm** :

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Here you can find a [live demo](https://content-hash.surge.sh/) of this package.
 * link to [npm](https://www.npmjs.com/package/content-hash)
 * link to [Github](https://github.com/pldespaigne/content-hash)
 
+Here you can also find a [Python version](https://github.com/filips123/ContentHashPy) of this package.
+
 ## 🔠 Supported Codec
 - `swarm-ns`
 - `ipfs-ns`

--- a/demo/main.js
+++ b/demo/main.js
@@ -34,8 +34,8 @@ window.onload = () => {
 		let url = 'https://'
 		if(codec === 'ipfs') url += 'gateway.ipfs.io/ipfs/' + cth + '/'
 		else if(codec === 'swarm') url += 'swarm-gateways.net/bzz:/' + cth + '/'
-		else if(codec === 'onion') url += cth + '/'
-		else if(codec === 'onion3') url += cth + '/'
+		else if(codec === 'onion') url = 'http://' + cth + '/'
+		else if(codec === 'onion3') url = 'http://' + cth + '/'
 		else if(codec === 'zeronet') url = 'http://127.0.0.1:43110/' + cth + '/'
 		else url = '#'
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -34,8 +34,8 @@ window.onload = () => {
 		let url = 'https://'
 		if(codec === 'ipfs') url += 'gateway.ipfs.io/ipfs/' + cth + '/'
 		else if(codec === 'swarm') url += 'swarm-gateways.net/bzz:/' + cth + '/'
-		else if(codec === 'onion') url = 'http://' + cth + '/'
-		else if(codec === 'onion3') url = 'http://' + cth + '/'
+		else if(codec === 'onion') url = 'http://' + cth + '.onion/'
+		else if(codec === 'onion3') url = 'http://' + cth + '.onion/'
 		else if(codec === 'zeronet') url = 'http://127.0.0.1:43110/' + cth + '/'
 		else url = '#'
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -27,10 +27,16 @@ window.onload = () => {
 		
 		if(contentHash.getCodec(contentInputElem.value) === 'ipfs-ns')codec = 'ipfs'
 		else if(contentHash.getCodec(contentInputElem.value) === 'swarm-ns')codec = 'swarm'
+		else if(contentHash.getCodec(contentInputElem.value) === 'onion')codec = 'onion'
+		else if(contentHash.getCodec(contentInputElem.value) === 'onion3')codec = 'onion3'
+		else if(contentHash.getCodec(contentInputElem.value) === 'zeronet')codec = 'zeronet'
 
 		let url = 'https://'
 		if(codec === 'ipfs') url += 'gateway.ipfs.io/ipfs/' + cth + '/'
 		else if(codec === 'swarm') url += 'swarm-gateways.net/bzz:/' + cth + '/'
+		else if(codec === 'onion') url += cth + '/'
+		else if(codec === 'onion3') url += cth + '/'
+		else if(codec === 'zeronet') url = 'http://127.0.0.1:43110/' + cth + '/'
 		else url = '#'
 
 		codecResultElem.innerHTML = 'codec : ' + codec

--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,9 +1524,9 @@
       }
     },
     "multicodec": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.4.tgz",
-      "integrity": "sha512-0lPLiZ58b2jyXylx2qgda9/6N0YCNIpBxRsZ8sxYayVjEKh58XyNN74VTTQOR/ZCQFgbj0CsqfyRpEDPPlOMkw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.5.tgz",
+      "integrity": "sha512-1kOifvwAqp9IdiiTKmpK2tS+LY6GHZdKpk3S2EvW4T32vlwDyA3hJoZtGauzqdedUPVNGChnTksEotVOCVlC+Q==",
       "requires": {
         "varint": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "cids": "^0.6.0",
-    "multicodec": "^0.5.4",
+    "multicodec": "^0.5.5",
     "multihashes": "^0.4.15"
   },
   "devDependencies": {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -118,6 +118,10 @@ const profiles = {
     encode: encodes.utf8,
     decode: decodes.utf8,
   },
+  'zeronet': {
+    encode: encodes.utf8,
+    decode: decodes.utf8,
+  },
 };
 
 exports.hexStringToBuffer = hexStringToBuffer;

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,8 @@ const onion = 'zqktlwi4fecvo6ri'
 const onion_contentHash = 'bc037a716b746c776934666563766f367269';
 const onion3 = 'p53lf57qovyuvwsc6xnrppyply3vtqm7l6pcobkmyqsiofyeznfu5uqd';
 const onion3_contentHash = 'bd037035336c663537716f7679757677736336786e72707079706c79337674716d376c3670636f626b6d797173696f6679657a6e667535757164';
+const zeronet = '1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D'
+const zeronet_contentHash = 'e6013148654c4c6f34757a6a614c65744678364e4833504d774650337162526254663344'
 
 describe('content-hash (legacy tests)', () => 
 	{
@@ -122,6 +124,20 @@ describe('content-hash', () => {
 		it('should decode', () => {
 			const actual = contentHash.decode(onion3_contentHash);
 			actual.should.be.equal(onion3);
+		});
+	});
+	describe('zeronet', () => {
+		it('should encode', () => {
+			const actual = contentHash.encode('zeronet', zeronet);
+			actual.should.be.equal(zeronet_contentHash);
+		});
+		it('should getCodec', () => {
+			const actual = contentHash.getCodec(zeronet_contentHash);
+			actual.should.be.equal('zeronet');
+		});
+		it('should decode', () => {
+			const actual = contentHash.decode(zeronet_contentHash);
+			actual.should.be.equal(zeronet);
 		});
 	});
 });


### PR DESCRIPTION
Add support for [ZeroNet](https://zeronet.io/) site address. ZeroNet uses old-style Bitcoin addresses as site addresses.

Also see multiformats/multicodec#140. This PR depends on multiformats/js-multicodec#48.