### PR TITLE
Improvements in demo & Link to Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Here you can find a [live demo](https://content-hash.surge.sh/) of this package.
 * link to [npm](https://www.npmjs.com/package/content-hash)
 * link to [Github](https://github.com/pldespaigne/content-hash)
 
+Here you can also find a [Python version](https://github.com/filips123/ContentHashPy) of this package.
+
 ## 🔠 Supported Codec
 - `swarm-ns`
 - `ipfs-ns`

--- a/demo/main.js
+++ b/demo/main.js
@@ -23,17 +23,20 @@ window.onload = () => {
 	contentButtonElem.addEventListener('click', () => {
 		let cth = contentHash.decode(contentInputElem.value)
 		
-		let codec = 'unknown'
-		
-		if(contentHash.getCodec(contentInputElem.value) === 'ipfs-ns')codec = 'ipfs'
-		else if(contentHash.getCodec(contentInputElem.value) === 'swarm-ns')codec = 'swarm'
+		let codec = contentHash.getCodec(contentInputElem.value)
+		let displayed = codec + ' (utf-8)'
 
-		let url = 'https://'
-		if(codec === 'ipfs') url += 'gateway.ipfs.io/ipfs/' + cth + '/'
-		else if(codec === 'swarm') url += 'swarm-gateways.net/bzz:/' + cth + '/'
+		if(codec === 'ipfs-ns')displayed = 'ipfs'
+		else if(codec === 'swarm-ns')displayed = 'swarm'
+
+		if(codec === 'ipfs-ns') url = 'https://gateway.ipfs.io/ipfs/' + cth + '/'
+		else if(codec === 'swarm-ns') url = 'https://swarm-gateways.net/bzz:/' + cth + '/'
+		else if(codec === 'onion') url = 'http://' + cth + '.onion/'
+		else if(codec === 'onion3') url = 'http://' + cth + '.onion/'
+		else if(codec === 'zeronet') url = 'http://127.0.0.1:43110/' + cth + '/'
 		else url = '#'
 
-		codecResultElem.innerHTML = 'codec : ' + codec
+		codecResultElem.innerHTML = 'codec : ' + displayed
 		contentResultElem.innerHTML = cth
 		contentResultElem.href = url
 	})


### PR DESCRIPTION
This contains some of the changes that were included in #33:

1. I created handling for default profiles. If decode example receives unknown profile, it displays it as codec name and adds `utf-8` notice. It now also handles few additional content-hash URLs (onion, onion3, zeronet).

2. I also linked my Python implementation from your README and your package from my README. Although this is a bit self-promotion, I think that it would be good to notify developers about other implementations of the content hash in different languages.