### PR TITLE
Update multicodec version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "cids": "^0.7.1",
-    "multicodec": "^0.5.5",
+    "multicodec": "^2.0.0",
     "multihashes": "^0.4.15"
   },
   "devDependencies": {


### PR DESCRIPTION
This package currently specifies multicodec ^0.5.5.  On installing this package or one that depends on it, that produces the following warning: 

>multicodec@0.5.7: stable api reached

While version 1 might be fine to get rid of that, they're [now at version 2](https://github.com/multiformats/js-multicodec/releases/tag/v2.0.0) and if going through to accommodate breaking changes, it might be worth just leapfrogging to the latest.

This is an incomplete PR (see failing tests below) but points out the specific line which triggers observability of the issue.
Viewing details of the test failure require logging in with a CircleCI account and giving CircleCI permissions to, at a minimum,

- read **and write** all public repository data as you
- read your organization, team membership, and private project boards
- read your private email addresses

which I don't agree to.